### PR TITLE
fix: remove extra spaces in error message leading to invalid path

### DIFF
--- a/tools/generators/grpc/xpcf_grpc_gen.pro
+++ b/tools/generators/grpc/xpcf_grpc_gen.pro
@@ -42,7 +42,7 @@ exists($${CPPAST_ROOT_BUILD}) {
     LIBS += -L$${CPPAST_ROOT_BUILD}/src -lcppast
     LIBS += -L$${CPPAST_ROOT_BUILD} -l_cppast_tiny_process
 } else {
-    error("cppast root build folder doesn't exist: create cppast root build folder and build cppast prior to running qmake.$$escape_expand(\\n)To build cppast do :$$escape_expand(\\n)cd " $${_PRO_FILE_PWD_} "/../../../libs/$$escape_expand(\\n)./build_cppast.sh" )
+    error("cppast root build folder doesn't exist: create cppast root build folder and build cppast prior to running qmake.$$escape_expand(\\n)To build cppast do :$$escape_expand(\\n)cd "$${_PRO_FILE_PWD_}"/../../../libs/$$escape_expand(\\n)./build_cppast.sh" )
 }
 win32:CONFIG -= static
 win32:CONFIG += shared


### PR DESCRIPTION
Remove extra space after 'cd' command
Remove extra space in built path, resulting in an invalid path

Error message before:
```
: -1: error: Project ERROR: cppast root build folder doesn't exist: create cppast root build folder and build cppast prior to running qmake.
To build cppast do :
cd  /home/user/work/xpcf/xpcf/tools/generators/grpc /../../../libs/
./build_cppast.sh
```

Error message after:
```
:  -1: error: Project ERROR: cppast root build folder doesn't exist: create cppast root build folder and build cppast prior to running qmake.
To build cppast do :
cd /home/user/work/xpcf/xpcf/tools/generators/grpc/../../../libs/
./build_cppast.sh
```