### PR TITLE
fix(grpcgen): remove ambiguous message about missing --file when using compilation database

### DIFF
--- a/tools/generators/grpc/xpcf_grpc_gen.cpp
+++ b/tools/generators/grpc/xpcf_grpc_gen.cpp
@@ -220,14 +220,6 @@ try
             serviceGenerator->setDestinationFolder(options["output"].as<std::string>());
         }
 
-        bool fileOptIsEmpty = !options.count("file") || options["file"].as<std::string>().empty();
-        bool databaseDirOptIsEmpty = !options.count("database_dir") || options["database_dir"].as<std::string>().empty();
-
-        if (!fileOptIsEmpty && !databaseDirOptIsEmpty) {
-            print_error("--file and --database_dir cannot be both set");
-            return 1;
-        }
-
         auto astParser = cmpMgr->resolve<ITypeParser>("astParser");
 
         int result = astParser->initOptions(options);
@@ -237,19 +229,21 @@ try
 
         cppast::cpp_entity_index idx; // the entity index is used to resolve cross references in the AST
 
-        if (!databaseDirOptIsEmpty) {
-            assert(fileOptIsEmpty);
-            if (int res = astParser->parse_database(options["database_dir"].as<std::string>(),options) != 0) {
-                return res;
+        if (!options.count("file") || options["file"].as<std::string>().empty()) {
+            if (options.count("database_dir") && !options["database_dir"].as<std::string>().empty()) {
+                std::cout<<"--file is not set : parsing every file listed in database"<<std::endl;
+                astParser->parse_database(options["database_dir"].as<std::string>(),options);
+                //parse_database(options["database_dir"].as<std::string>(),idx,options, [&](const cppast::cpp_entity_index& idx, std::ostream& out, const cppast::cpp_file& file) { astParser->parseAst(idx,out,file); });
             }
-            //parse_database(options["database_dir"].as<std::string>(),idx,options, [&](const cppast::cpp_entity_index& idx, std::ostream& out, const cppast::cpp_file& file) { astParser->parseAst(idx,out,file); });
-        } else if (!fileOptIsEmpty) {
-            if (int res = astParser->parse_file(options["file"].as<std::string>(), options.count("fatal_errors") == 1) != 0) {
-                return res;
+            else {
+                print_error("missing one of file or database dir argument");
+                return 1;
             }
-        } else {
-            print_error("missing one of --file or --database_dir argument");
-            return 1;
+        }
+        else {
+            result = astParser->parse_file(options["file"].as<std::string>(), options.count("fatal_errors") == 1);
+            if (result != 0)
+                return result;
         }
 
         //update types : try to qualify non fqdn types in parameters ... from classes found during parsing

--- a/tools/generators/grpc/xpcf_grpc_gen.cpp
+++ b/tools/generators/grpc/xpcf_grpc_gen.cpp
@@ -238,12 +238,12 @@ try
         cppast::cpp_entity_index idx; // the entity index is used to resolve cross references in the AST
 
         if (!databaseDirOptIsEmpty) {
+            assert(fileOptIsEmpty);
             if (int res = astParser->parse_database(options["database_dir"].as<std::string>(),options) != 0) {
                 return res;
             }
             //parse_database(options["database_dir"].as<std::string>(),idx,options, [&](const cppast::cpp_entity_index& idx, std::ostream& out, const cppast::cpp_file& file) { astParser->parseAst(idx,out,file); });
         } else if (!fileOptIsEmpty) {
-            assert(databaseDirOptIsEmpty);
             if (int res = astParser->parse_file(options["file"].as<std::string>(), options.count("fatal_errors") == 1) != 0) {
                 return res;
             }


### PR DESCRIPTION
When using a compilation database, a message stating that the "File was missing" was printed, leading to think something was wrong whereas it's expected behavior.

Also:
- perform option validation to keep --file and --database_dir mutually exclusive (if both options were set, only file was taken)
- handle parsing error (used to be ignored for --database_dir path)